### PR TITLE
add simple robot sheet

### DIFF
--- a/module/actor/sheet.js
+++ b/module/actor/sheet.js
@@ -42,6 +42,7 @@ export default class esActorSheet extends ActorSheet {
     // console.log("E-STATE | Actor", actor);
     // console.log("E-STATE |  Data", data);
     this.computeItems(data);
+    this.computeGear(actor);
     this.computeMaxStats(actor);
     this.checkBliss(actor);
     this.checkHealth(actor);
@@ -80,6 +81,22 @@ export default class esActorSheet extends ActorSheet {
 
     await item.update({ "flags.isEquipped": equipStatus });
     console.log("E-STATE | Item", item);
+  }
+
+  _isPlayer() {
+    return this.actor.type === "player";
+  }
+
+  _isNpc() {
+    return this.actor.type === "npc";
+  }
+
+  _isRobot() {
+    return this.actor.type === "robot";
+  }
+
+  _isVehicule() {
+    return this.actor.type === "vehicle";
   }
 
   async _onToggleFav(event) {
@@ -333,5 +350,14 @@ export default class esActorSheet extends ActorSheet {
       item.isTrauma = item.type === "trauma";
       item.isInjury = item.type === "injury";
     }
+  }
+
+  computeGear(actor) {
+    actor.hasWeapon = this._isPlayer() || this._isNpc() || this._isRobot();
+    actor.hasExplosive = this._isPlayer() || this._isNpc();
+    actor.hasGear= this._isPlayer() || this._isNpc();
+    actor.hasArmor = this._isPlayer() || this._isNpc() || this._isRobot();
+    actor.hasDrone = this._isPlayer() || this._isNpc();
+    actor.hasNeurocaster = this._isPlayer() || this._isNpc();
   }
 }

--- a/module/templates.js
+++ b/module/templates.js
@@ -17,7 +17,8 @@ export const preloadHandlebarsTemplates = async function() {
         "systems/electric-state/templates/actors/parts/player-notes.hbs",
         "systems/electric-state/templates/actors/parts/npc-main.hbs",
         "systems/electric-state/templates/actors/parts/npc-notes.hbs",
-
+        "systems/electric-state/templates/actors/parts/robot-main.hbs",
+        "systems/electric-state/templates/actors/parts/robot-notes.hbs",
     ];
   
     // Load the template parts

--- a/templates/actors/parts/gear.hbs
+++ b/templates/actors/parts/gear.hbs
@@ -1,4 +1,5 @@
 <div class="flexcol">
+    {{#if actor.hasWeapon}}
     <div class="weapon-group">
         <div class="group-header flexrow">
             <h4>weapons</h4>
@@ -20,6 +21,8 @@
         {{/if}}
         {{/each}}
     </div>
+    {{/if}}
+    {{#if actor.hasExplosive}}
     <div class="explosives-group">
         <div class="group-header flexrow">
             <h4>explosives</h4>
@@ -41,6 +44,8 @@
         {{/if}}
         {{/each}}
     </div>
+    {{/if}}
+    {{#if actor.hasArmor}}
     <div class="armor-group">
         <div class="group-header flexrow">
             <h4>armor</h4>
@@ -68,6 +73,8 @@
         {{/if}}
         {{/each}}
     </div>
+    {{/if}}
+    {{#if actor.hasGear}}
     <div class="gear-group">
         <div class="group-header flexrow">
             <h4>gear</h4>
@@ -99,7 +106,9 @@
         {{/if}}
         {{/each}}
     </div>
-    <div class="drone-gorup">
+    {{/if}}
+    {{#if actor.hasDrone}}
+    <div class="drone-group">
         <div class="group-header flexrow">
             <h4>drone</h4>
             <div class="item-create" data-type="drone">new drone</div>
@@ -128,6 +137,8 @@
         {{/if}}
         {{/each}}
     </div>
+    {{/if}}
+    {{#if actor.hasNeurocaster}}
     <div class="neurocaster-group">
         <div class="group-header flexrow">
             <h4>neurocaster</h4>
@@ -155,4 +166,5 @@
         {{/if}}
         {{/each}}
     </div>
+    {{/if}}
 </div>

--- a/templates/actors/parts/robot-main.hbs
+++ b/templates/actors/parts/robot-main.hbs
@@ -1,0 +1,22 @@
+<div class="grid gap-small"></div>
+    <div class="flexcol  border-3-4-thick padding-small">
+         {{> "systems/electric-state/templates/actors/parts/stats.hbs"}}
+        <div class="flexrow">
+            <div class="flexrow all-caps fw-700 border-bottom-thin align-bottom mi-small">
+                {{localize "estate.UI.HULL"}}
+                <div class="input-container mi-small center"> 
+                    <input type="text" name="system.hull.value" value="{{actor.system.hull.value}}" style="width: 50px" data-dtype="Number" />
+                </div>
+                <div>/</div>
+                <div class="input-container mi-small center">
+                    <input type="text" name="system.hull.max" value="{{actor.system.hull.max}}" style="width: 50px" data-dtype="Number" />
+                </div>
+            </div>
+        </div>
+        <div class="flexrow gap-small">
+            <div class="flexcol padding-small">
+                {{> "systems/electric-state/templates/actors/parts/gear.hbs"}}
+            </div>
+        </div>
+    </div>
+</div>

--- a/templates/actors/parts/robot-notes.hbs
+++ b/templates/actors/parts/robot-notes.hbs
@@ -1,0 +1,7 @@
+<div>
+    <div class="container">
+        <div class="full-size">
+            {{editor notesHTML target="system.notes" button=true owner=owner editable=editable}}
+        </div>
+    </div>
+</div>

--- a/templates/actors/robot.hbs
+++ b/templates/actors/robot.hbs
@@ -1,0 +1,41 @@
+<form class="actor-sheet {{cssClass}}" autocomplete="off">
+    <div class="grid col-160-1fr border-thick">
+        <div class="portrait">
+            <img src="{{actor.img}}" data-edit="img" title="{{actor.name}}" height="160" width="160" />
+        </div>
+        <div class="flexcol padding-small">
+            <div class="flexrow align-content-start gap-small">
+                <div class="charname grid col-20-80 align-bottom border-bottom">
+                    <lable class="shrink">{{localize "estate.HEAD.NAME"}}</lable>
+                    <input name="name" type="text" value="{{actor.name}}" placeholder="name" />
+                </div>
+            </div>
+            <div class="flexrow align-content-start gap-small">
+                <div class="description grid col-20-80 align-bottom border-bottom">
+                    <lable class="shrink">{{localize "estate.HEAD.DESC"}}</lable>
+                    <textarea name="system.description">{{actor.system.description}}</textarea>
+                </div>
+            </div>
+        </div>
+    </div>
+
+    <div class="flexcol">
+        <div class="sheet-tabs tabs flexrow border-3-4-thick" data-group="primary">
+            <b class="item border-right-thick padding-small" data-tab="main">{{localize "estate.UI.MAIN"}}</b>
+            <b class="item padding-small" data-tab="notes">{{localize "estate.UI.NOTES"}}</b>
+        </div>
+        <div class="sheet-body">
+            <div class="tab" data-group="primary" data-tab="main">
+                <div class="main flexcol">
+                    {{> "systems/electric-state/templates/actors/parts/robot-main.hbs"}}
+                </div>
+            </div>
+
+            <div class="tab" data-group="primary" data-tab="notes">
+                <div class="main flexcol">
+                    {{> "systems/electric-state/templates/actors/parts/robot-notes.hbs"}}
+                </div>
+            </div>
+        </div>
+    </div>
+</form>


### PR DESCRIPTION
Super simple robot sheet.

Attacks and Armor are basically normal items (weapon and armor types) that you add to the robot.

The only thing that does't work is that robots have physical and neuroscape weapons/attacks. Physical weapons work like normal weapons, but neuroscape weapons use Wits (which can not be assigned at this moment on a weapon).

I was thinking of adding a new weapon type (Neuroscape Combat), this way we can make the roll use Wits.
We could also split physical weapons/attacks and neuroscape weapons on the robot sheet I think.

What do you think?

Here are a couple of screenshots:

<img width="626" alt="Screenshot 2024-09-25 at 3 22 06 PM" src="https://github.com/user-attachments/assets/e8c045be-0405-4f58-b799-48fadb07e284">
<img width="621" alt="Screenshot 2024-09-25 at 3 22 13 PM" src="https://github.com/user-attachments/assets/6ed38831-110d-4415-9996-8a37d883f70f">


